### PR TITLE
Add support for RS485 using the MAX485 chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# About this Fork
+# About this fork
+As an addition to the fork by https://github.com/wickersoft/daly-bms-uart, this adds support for using the MAX485 chip for RS485 communications. 
+The DE and RE IO pins to allows RS485 comms. If DE and RE are on a single IO pin (as allowed with MAX485) the default RE pin assignment of 0 can be set.
+
+# About /wickersoft/daly-bms-uart Fork
 In the original repo by maland16, the library is built for a Teensy 4.0. This repo is supposed to be functionally identical to the original, but run on boards of the ATmega328Px family (Arduino Uno, Nano, Pro Mini, etc). 
 Because the ATmega328 has only one hardware serial port and this is used for programming and debugging, communication with the BMS is done via SoftwareSerial. Stability tests have not yet been carried out. 
 

--- a/daly-bms-uart.cpp
+++ b/daly-bms-uart.cpp
@@ -8,10 +8,19 @@
 //----------------------------------------------------------------------
 // Public Functions
 //----------------------------------------------------------------------
+Daly_BMS_UART::Daly_BMS_UART(SoftwareSerial &serialIntf, uint8_t DE_pin, uint8_t RE_pin=0 )
+    :Daly_BMS_UART(serialIntf)
+{
+    this->my_DE_pin = DE_pin;
+    this->my_RE_pin = RE_pin;    
+}
+
 
 Daly_BMS_UART::Daly_BMS_UART(SoftwareSerial &serial_peripheral)
 {
     this->my_serialIntf = &serial_peripheral;
+    this->my_DE_pin = 0;
+    this->my_RE_pin = 0;    
 }
 
 bool Daly_BMS_UART::Init()
@@ -43,6 +52,18 @@ bool Daly_BMS_UART::Init()
     for (uint8_t i = 4; i < 12; i++)
     {
         this->my_txBuffer[i] = 0x00;
+    }
+
+    if( this->my_DE_pin != 0)
+    {
+        pinMode(this->my_DE_pin, OUTPUT);
+        digitalWrite(this->my_DE_pin,LOW);	
+    }
+
+    if( this->my_RE_pin != 0)
+    {
+        pinMode(this->my_RE_pin, OUTPUT);
+        digitalWrite(this->my_RE_pin,LOW);
     }
 
     return true;
@@ -533,13 +554,31 @@ void Daly_BMS_UART::sendCommand(COMMAND cmdID)
     this->my_txBuffer[12] = checksum;
 
 #ifdef DEBUG_SERIAL
-    DEBUG_SERIAL.print("<DALY-BMS DEBUG> Send command: 0x");
+    DEBUG_SERIAL.print(F("<DALY-BMS DEBUG> Send command: 0x"));
     DEBUG_SERIAL.print(cmdID, HEX);
-    DEBUG_SERIAL.print(" Checksum = 0x");
+    DEBUG_SERIAL.print(F(" Checksum = 0x"));
     DEBUG_SERIAL.println(checksum, HEX);
 #endif
 
+    if( this->my_RE_pin != 0)
+    {
+        digitalWrite(this->my_RE_pin,HIGH);
+    }
+    if( this->my_DE_pin != 0)
+    {
+        digitalWrite(this->my_DE_pin,HIGH);
+    }
+
     this->my_serialIntf->write(this->my_txBuffer, XFER_BUFFER_LENGTH);
+
+    if( this->my_RE_pin != 0)
+    {
+        digitalWrite(this->my_RE_pin,LOW);
+    }
+    if( this->my_DE_pin != 0)
+    {
+        digitalWrite(this->my_DE_pin,LOW);
+    }
 }
 
 bool Daly_BMS_UART::receiveBytes(void)

--- a/daly-bms-uart.h
+++ b/daly-bms-uart.h
@@ -28,6 +28,13 @@ public:
         BMS_RESET = 0x00,
     };
 
+    enum CHARGE_DISCHARGE_STATUS
+    {
+        STATIONARY = 0,
+        CHARGE = 1,
+        DISCHARGE = 2,
+    };
+
     /**
      * @brief get struct holds all the data collected from the BMS and is populated using the update() API
      * @details Comments specify precision and units where applicable
@@ -52,7 +59,7 @@ public:
         float tempAverage; // Average of temp sensors
 
         // data from 0x93
-        String chargeDischargeStatus; // charge/discharge status (0 stationary, 1 charge, 2 discharge)
+        CHARGE_DISCHARGE_STATUS chargeDischargeStatus; // charge/discharge status (0 stationary, 1 charge, 2 discharge)
         bool chargeFetState;          // charging MOSFET status
         bool disChargeFetState;       // discharge MOSFET state
         int bmsHeartBeat;             // BMS life (0~255 cycles)?

--- a/daly-bms-uart.h
+++ b/daly-bms-uart.h
@@ -157,6 +157,15 @@ public:
      * @param serialIntf UART interface BMS is connected to
      */
     Daly_BMS_UART(SoftwareSerial &serialIntf);
+    
+    /**
+     * @brief Construct a new Daly_BMS_UART object for RS485
+     *
+     * @param serialIntf UART interface BMS is connected to, 
+     * @param DE_pin is the driver_enable IO pin
+     * @param RE_pin is the receiver_enable IO pin 
+     */
+    Daly_BMS_UART(SoftwareSerial &serialIntf, uint8_t DE_pin, uint8_t RE_pin=0 );
 
     /**
      * @brief Initializes this driver
@@ -282,6 +291,18 @@ private:
      * @details This is set in the constructor
      */
     SoftwareSerial *my_serialIntf;
+
+    /**
+     * @brief DE_pin as set for RS485 communications. Set to 0 for no usage
+     * @details This is set in the constructor
+     */
+    uint8_t my_DE_pin = 0;
+
+    /**
+     * @brief RE_pin as set for RS485 communications. Set to 0 for no usage
+     * @details This is set in the constructor
+     */
+    uint8_t my_RE_pin = 0;
 
     /**
      * @brief Buffer used to transmit data to the BMS

--- a/daly-bms-uart.h
+++ b/daly-bms-uart.h
@@ -56,7 +56,7 @@ public:
         bool chargeFetState;          // charging MOSFET status
         bool disChargeFetState;       // discharge MOSFET state
         int bmsHeartBeat;             // BMS life (0~255 cycles)?
-        int resCapacitymAh;           // residual capacity mAH
+        uint32_t resCapacitymAh;           // residual capacity mAH
 
         // data from 0x94
         int numberOfCells;    // Cell count


### PR DESCRIPTION
This adds support for using the MAX485 chip for RS485 communications. The DE and RE IO pins are assigned in a new constructor to the class. These are required to allow RS485 comms. If DE and RE are on a single IO pin (as allowed with MAX485) the default RE pin assignment of 0 can be set.